### PR TITLE
wait for ncp call to complete

### DIFF
--- a/HttpTrigger1/index.js
+++ b/HttpTrigger1/index.js
@@ -2,18 +2,27 @@ const JsReport = require('jsreport')
 const path = require('path')
 const ncp = require('ncp')
 
-let jsreport
-const init = (async () => {    
-    jsreport = JsReport({
-        configFile: path.join(__dirname, '../', 'prod.config.json')
-    })    
-    await ncp(path.join(__dirname, '../', 'data'), '/tmp/data')
-    return jsreport.init()
-})()
+const init = (() => {
+    return new Promise((resolve, reject) => {        
+        ncp(path.join(__dirname, '../', 'data'), '/tmp/data', function (err) {
+            if (err) {
+              console.error(err);
+              return reject(err);
+            }
+            
+            const jsreport = JsReport({
+                configFile: path.join(__dirname, '../', 'prod.config.json')
+            })            
+            jsreport.init().then(() => {
+                resolve(jsreport);
+            })
+        })
+      });    
+})();
 
 module.exports = async function (context, req) {
     try {
-        await init
+        const jsreport = await init;
         // use the request body from post, if not specified return a sample template report for preview in browser
         const res = await jsreport.render(req.body || {
             template: {


### PR DESCRIPTION
ncp does not return a promise so its not awaitable, instead the done callback needs to be used. This resolves the race condition where templates are not finished moving before the template rendering starts. 

This issue causes all sorts of problems when more templates are added, including errors reporting missing templates and empty files being rendered.